### PR TITLE
Fix wrong parameter name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The `secrets.SLACK_WEBHOOK_URL` must be legacy one.
 ```yaml
 - uses: sonots/slack-notice-action@v3
   with:
-    type: ${{ job.status }}
+    status: ${{ job.status }}
     username: Custom Username
     icon_emoji: ':octocat:'
     channel: '#integration-test'


### PR DESCRIPTION
Hello,

I run into the following error using legacy Slack API. Is  `type` parameter correct?

```
##[error]Input required and not supplied: status
```