### PR TITLE
use node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,7 +37,7 @@ inputs:
     description: override the legacy integration's default channel. This should be an ID, such as C8UJ12P4P.
     default: ''
 runs:
-  using: node16
+  using: node20
   main: dist/index.js
 branding:
   icon: bell


### PR DESCRIPTION
Hello.

Node.js 16 actions are deprecated.
So I changed it to use node v20.

ref. https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
ref. https://github.com/8398a7/action-slack/pull/246

If there is no problem, please release it.
