### PR TITLE
Use node24 runtime

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,7 +37,7 @@ inputs:
     description: override the legacy integration's default channel. This should be an ID, such as C8UJ12P4P.
     default: ''
 runs:
-  using: node20
+  using: node24
   main: dist/index.js
 branding:
   icon: bell


### PR DESCRIPTION
GitHub Actions has [deprecated the node20 runtime](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/):

- 2026-06-02: node24 becomes the default
- 2026-09-16: node20 is removed from the runner

Bump `runs.using` from `node20` to `node24` so this action keeps working. The bundled `dist/index.js` is a self-contained ncc build and runs on node24 without rebuild.