### PR TITLE
feat!: drop legacy Incoming Webhook support

### DIFF
--- a/.github/workflows/slack-mainline.yml
+++ b/.github/workflows/slack-mainline.yml
@@ -37,15 +37,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_FOR_INTEGRATION_TEST }}
-      - name: Legacy Check
-        uses: sonots/slack-notice-action@v3
-        with:
-          status: ${{ job.status }}
-          username: legacy user
-          icon_emoji: ':octocat:'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_LEGACY_WEBHOOK_URL_FOR_INTEGRATION_TEST }}
       - name: Custom Field Check
         uses: sonots/slack-notice-action@v3
         with:

--- a/.github/workflows/slack-pre.yml
+++ b/.github/workflows/slack-pre.yml
@@ -30,15 +30,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_FOR_INTEGRATION_TEST }}
-      - name: Legacy Check
-        uses: sonots/slack-notice-action@pre
-        with:
-          status: ${{ job.status }}
-          username: legacy user
-          icon_emoji: ':octocat:'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_LEGACY_WEBHOOK_URL_FOR_INTEGRATION_TEST }}
       - name: Custom Field Check
         uses: sonots/slack-notice-action@pre
         with:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,15 +1,14 @@
 ## Prepare Webhook URLs
 
-The CI workflows reference three repository secrets. Both integration-test
-secrets must be valid for the `Slack Pre` / `Slack Mainline` workflows to pass.
+The CI workflows reference two repository secrets. The integration-test secret
+must be valid for the `Slack Pre` / `Slack Mainline` workflows to pass.
 
 | Secret | Type | Used by |
 |---|---|---|
 | `SLACK_WEBHOOK_URL` | Modern (Slack App) | `test.yml`, `release.yml`, and the trailing notification step in `slack-pre.yml` / `slack-mainline.yml` |
 | `SLACK_WEBHOOK_URL_FOR_INTEGRATION_TEST` | Modern (Slack App) | `slack-pre.yml`, `slack-mainline.yml` |
-| `SLACK_LEGACY_WEBHOOK_URL_FOR_INTEGRATION_TEST` | Legacy Incoming Webhook | "Legacy Check" step of `slack-pre.yml` / `slack-mainline.yml` |
 
-### 1. Create a modern Incoming Webhook (Slack App)
+### 1. Create an Incoming Webhook (Slack App)
 
 Used for `SLACK_WEBHOOK_URL` and `SLACK_WEBHOOK_URL_FOR_INTEGRATION_TEST`.
 
@@ -24,58 +23,25 @@ You can reuse the same URL for both `SLACK_WEBHOOK_URL` and
 `SLACK_WEBHOOK_URL_FOR_INTEGRATION_TEST`, or create two separate webhooks if you
 want to route them to different channels.
 
-### 2. Create a legacy Incoming Webhook
-
-Used for `SLACK_LEGACY_WEBHOOK_URL_FOR_INTEGRATION_TEST`.
-
-1. Open https://slack.com/services/new/incoming-webhook (must be signed into the workspace).
-2. Choose the **Post to Channel** target and click **Add Incoming WebHooks integration**.
-3. Copy the generated `https://hooks.slack.com/services/T.../B.../...` URL.
-
-Caveats:
-
-- Slack is phasing out legacy custom integrations. The admin toggle that used
-  to live under **Workspace settings → Permissions → Apps, Custom Integrations
-  & Sandbox** has been removed from the UI on many workspaces (newer
-  workspaces, Enterprise Grid org-managed workspaces, and workspaces that
-  Slack has already migrated). If you cannot find that toggle, the option is
-  not available to you — even as a workspace admin — and there is no path to
-  re-enable legacy webhook creation.
-- On migrated workspaces the section may still be visible under a renamed
-  heading such as **"Apps & Custom Integrations"** with a description like
-  *"Manage permissions for apps and integrations from the Slack Marketplace"*.
-  Despite the name, this surface now governs **marketplace app installation
-  approval only**; the legacy custom-integration creation control has been
-  stripped out. Seeing this section does not mean legacy webhooks can be
-  created — they cannot.
-- **Recommended fallback:** put a modern Slack App webhook URL into
-  `SLACK_LEGACY_WEBHOOK_URL_FOR_INTEGRATION_TEST` as well. The action's runtime
-  code is identical for both URL types (`new IncomingWebhook(url).send(...)`).
-  Modern webhooks silently ignore the `username` / `icon_emoji` override that
-  legacy webhooks honored, but they still return HTTP 200, so the "Legacy
-  Check" step passes. The only loss is the visible difference in the posted
-  message's sender name/icon — CI status and release readiness are unaffected.
-
-### 3. Register the secrets on GitHub
+### 2. Register the secrets on GitHub
 
 Repository admin permission is required.
 
 **Web UI:** open
 <https://github.com/sonots/slack-notice-action/settings/secrets/actions>,
 click **New repository secret**, paste the URL into *Value*, and **Add secret**.
-Repeat for each of the three secrets above.
+Repeat for each of the two secrets above.
 
 **`gh` CLI:**
 
 ```
 $ gh secret set SLACK_WEBHOOK_URL                             -R sonots/slack-notice-action
 $ gh secret set SLACK_WEBHOOK_URL_FOR_INTEGRATION_TEST        -R sonots/slack-notice-action
-$ gh secret set SLACK_LEGACY_WEBHOOK_URL_FOR_INTEGRATION_TEST -R sonots/slack-notice-action
 ```
 
 Each command prompts for the value — paste the webhook URL and press Enter.
 
-### 4. Verify
+### 3. Verify
 
 Push an empty commit to `pre` to trigger the `Slack Pre` integration workflow:
 
@@ -85,8 +51,8 @@ $ git push origin pre
 ```
 
 Every step in the `notification` job (Succeeded Check / Failed Check /
-Cancelled Check / Legacy Check / Custom Field Check / final Check) should turn
-green and the corresponding messages should appear in the Slack channel.
+Cancelled Check / Custom Field Check / final Check) should turn green and the
+corresponding messages should appear in the Slack channel.
 
 ### Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Yet Another GitHub Action to notify slack.
     only_mention_fail: 'channel'
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Required, but this should be automatically supplied by GitHub.
-    SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # Required. Legacy Incoming Webhook is also supported.
+    SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # Required. A Slack App Incoming Webhook URL.
   if: always() # Pick up events even if the job fails or is canceled.
 ```
 
@@ -38,15 +38,6 @@ Yet Another GitHub Action to notify slack.
 | mention           | `here` or `channel` or user\_id such as `user_id,user_id2` | ''                    | Mention always if specified. The user ID should be an ID, such as `@U024BE7LH`. See [Mentioning Users](https://api.slack.com/reference/surfaces/formatting#mentioning-users) |
 | only_mention_fail | `here` or `channel` or user\_id such as `user_id,user_id2` | ''                    | Mention only on failure if specified      |
 
-Supported by only legacy incoming webhook.
-
-| key               | value | default  | description                                                                                                 |
-| ----------------- | ----- | ---------| ----------------------------------------------------------------------------------------------------------- |
-| username          |       | ''       | override the legacy integration's default name.                                                             |
-| icon_emoji        |       | ''       | an [emoji code](https://www.webfx.com/tools/emoji-cheat-sheet/) string to use in place of the default icon. |
-| icon_url          |       | ''       | an icon image URL string to use in place of the default icon.                                               |
-| channel           |       | ''       | override the legacy integration's default channel. This should be an ID, such as `C8UJ12P4P`.               |
-
 Custom notification. See [Custom Notification](https://github.com/sonots/slack-notice-action#custom-notification) for details.
 
 | key               | value | default  | description                                                                                                 |
@@ -54,21 +45,6 @@ Custom notification. See [Custom Notification](https://github.com/sonots/slack-n
 | payload           |       | ''       | Only available when status: custom. The payload format can pass javascript object.                          |
 
 ## Example
-
-Legacy Incoming Webhook Example:
-
-```yaml
-- uses: sonots/slack-notice-action@v3
-  with:
-    status: ${{ job.status }}
-    username: Custom Username
-    icon_emoji: ':octocat:'
-    channel: 'C8UJ12P4P'
-  env:
-    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Required, but this should be automatically supplied by GitHub.
-    SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # Required. Legacy Incoming Webhook is also supported.
-  if: always() # Pick up events even if the job fails or is canceled.
-```
 
 In case of success:
 

--- a/README.md
+++ b/README.md
@@ -127,11 +127,21 @@ post time, so you choose the destination once on the Slack side:
 
 1. Open <https://api.slack.com/apps> → your app → **Incoming Webhooks**
 2. Click **Add New Webhook to Workspace** and select the target channel
-3. Save the URL as the `SLACK_WEBHOOK_URL` secret (see Quick Start above)
+3. Save the URL as the `SLACK_WEBHOOK_URL` secret
 
-If you need to post to multiple channels, repeat steps 1–3 for each
-channel and store each URL as a separate secret, then pass whichever
-one a given step needs to `SLACK_WEBHOOK_URL`.
+If you need to post to multiple channels, repeat steps 2–3 for each
+channel and store each URL as its own secret (e.g.
+`SLACK_WEBHOOK_URL_RELEASES`, `SLACK_WEBHOOK_URL_ALERTS`), then pass
+whichever one a given step needs:
+
+```yaml
+- uses: sonots/slack-notice-action@v4
+  with:
+    status: ${{ job.status }}
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_RELEASES }}
+```
 
 ### `username` / `icon_emoji` / `icon_url`: configure on the Slack App
 

--- a/README.md
+++ b/README.md
@@ -119,16 +119,20 @@ per message, and those four inputs have therefore been removed.
 
 If you previously used those inputs, here is how to migrate:
 
-### `channel`: one webhook URL per channel
+### `channel`: choose the channel when creating the webhook
 
 A Slack App Incoming Webhook URL is permanently bound to the channel
-you pick when authorizing the app. To post to multiple channels, create
-multiple webhooks and reference each as a separate secret.
+you pick when authorizing the app. There is no way to override it at
+post time, so you choose the destination once on the Slack side:
 
 1. Open <https://api.slack.com/apps> → your app → **Incoming Webhooks**
 2. Click **Add New Webhook to Workspace** and select the target channel
-3. Save the URL as a secret (e.g. `SLACK_WEBHOOK_URL_RELEASES`)
-4. Pass the right secret to `SLACK_WEBHOOK_URL` in each step
+3. Save the URL as the `SLACK_WEBHOOK_URL` secret
+
+If you need to post to multiple channels, repeat steps 2–3 for each
+channel and store each URL as its own secret (e.g.
+`SLACK_WEBHOOK_URL_RELEASES`, `SLACK_WEBHOOK_URL_ALERTS`), then pass
+whichever one a given step needs:
 
 ```yaml
 - uses: sonots/slack-notice-action@v4

--- a/README.md
+++ b/README.md
@@ -127,21 +127,11 @@ post time, so you choose the destination once on the Slack side:
 
 1. Open <https://api.slack.com/apps> → your app → **Incoming Webhooks**
 2. Click **Add New Webhook to Workspace** and select the target channel
-3. Save the URL as the `SLACK_WEBHOOK_URL` secret
+3. Save the URL as the `SLACK_WEBHOOK_URL` secret (see Quick Start above)
 
-If you need to post to multiple channels, repeat steps 2–3 for each
-channel and store each URL as its own secret (e.g.
-`SLACK_WEBHOOK_URL_RELEASES`, `SLACK_WEBHOOK_URL_ALERTS`), then pass
-whichever one a given step needs:
-
-```yaml
-- uses: sonots/slack-notice-action@v4
-  with:
-    status: ${{ job.status }}
-  env:
-    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_RELEASES }}
-```
+If you need to post to multiple channels, repeat steps 1–3 for each
+channel and store each URL as a separate secret, then pass whichever
+one a given step needs to `SLACK_WEBHOOK_URL`.
 
 ### `username` / `icon_emoji` / `icon_url`: configure on the Slack App
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,54 @@ See also:
 - [Reference: Message payloads](https://api.slack.com/reference/messaging/payload)
 
 
+## Migrating from Legacy Incoming Webhook (v3 → v4)
+
+`v3` and earlier supported legacy custom-integration Incoming Webhooks
+and exposed `username` / `icon_emoji` / `icon_url` / `channel` inputs to
+override the sender and target channel per message.
+
+Slack has phased out legacy custom integrations, so `v4` only supports
+**Slack App** Incoming Webhooks. With Slack App webhooks, channel and
+sender appearance are configured **once on the Slack side** instead of
+per message, and those four inputs have therefore been removed.
+
+If you previously used those inputs, here is how to migrate:
+
+### `channel`: one webhook URL per channel
+
+A Slack App Incoming Webhook URL is permanently bound to the channel
+you pick when authorizing the app. To post to multiple channels, create
+multiple webhooks and reference each as a separate secret.
+
+1. Open <https://api.slack.com/apps> → your app → **Incoming Webhooks**
+2. Click **Add New Webhook to Workspace** and select the target channel
+3. Save the URL as a secret (e.g. `SLACK_WEBHOOK_URL_RELEASES`)
+4. Pass the right secret to `SLACK_WEBHOOK_URL` in each step
+
+```yaml
+- uses: sonots/slack-notice-action@v4
+  with:
+    status: ${{ job.status }}
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_RELEASES }}
+```
+
+### `username` / `icon_emoji` / `icon_url`: configure on the Slack App
+
+Slack App webhooks ignore per-message sender overrides. Set the name
+and icon on the app itself, and they apply to every webhook the app
+posts:
+
+1. Open <https://api.slack.com/apps> → your app → **Basic Information**
+2. Under **Display Information**, set the app name and icon
+3. Save — changes take effect immediately for all of the app's webhooks
+
+If you need different sender appearances for different notifications,
+create separate Slack Apps (each with its own name/icon) and use each
+app's webhook URL where appropriate.
+
+
 ## Special Thanks
 
 This orginally started as a fork of https://github.com/8398a7/action-slack. Thanks!

--- a/action.yml
+++ b/action.yml
@@ -24,18 +24,6 @@ inputs:
   text:
     description: You can overwrite text.
     default: ''
-  username:
-    description: override the legacy integration's default name.
-    default: ''
-  icon_emoji:
-    description: an emoji code string to use in place of the default icon.
-    default: ''
-  icon_url:
-    description: an icon image URL string to use in place of the default icon.
-    default: ''
-  channel:
-    description: override the legacy integration's default channel. This should be an ID, such as C8UJ12P4P.
-    default: ''
 runs:
   using: node24
   main: dist/index.js

--- a/dist/index.js
+++ b/dist/index.js
@@ -70415,13 +70415,8 @@ class Client {
     }
     async payloadTemplate() {
         const text = this.mentionText(this.with.mention);
-        const { username, icon_emoji, icon_url, channel } = this.with;
         return {
             text,
-            username,
-            icon_emoji,
-            icon_url,
-            channel,
             attachments: [
                 {
                     color: '',
@@ -70650,10 +70645,6 @@ async function run() {
         const text_on_success = _actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput('text_on_success');
         const text_on_fail = _actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput('text_on_fail');
         const text_on_cancel = _actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput('text_on_cancel');
-        const username = _actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput('username');
-        const icon_emoji = _actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput('icon_emoji');
-        const icon_url = _actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput('icon_url');
-        const channel = _actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput('channel');
         const rawPayload = _actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput('payload');
         _actions_core__WEBPACK_IMPORTED_MODULE_0__.debug(`status: ${status}`);
         _actions_core__WEBPACK_IMPORTED_MODULE_0__.debug(`mention: ${mention}`);
@@ -70663,10 +70654,6 @@ async function run() {
         _actions_core__WEBPACK_IMPORTED_MODULE_0__.debug(`text_on_success: ${text_on_success}`);
         _actions_core__WEBPACK_IMPORTED_MODULE_0__.debug(`text_on_fail: ${text_on_fail}`);
         _actions_core__WEBPACK_IMPORTED_MODULE_0__.debug(`text_on_cancel: ${text_on_cancel}`);
-        _actions_core__WEBPACK_IMPORTED_MODULE_0__.debug(`username: ${username}`);
-        _actions_core__WEBPACK_IMPORTED_MODULE_0__.debug(`icon_emoji: ${icon_emoji}`);
-        _actions_core__WEBPACK_IMPORTED_MODULE_0__.debug(`icon_url: ${icon_url}`);
-        _actions_core__WEBPACK_IMPORTED_MODULE_0__.debug(`channel: ${channel}`);
         _actions_core__WEBPACK_IMPORTED_MODULE_0__.debug(`rawPayload: ${rawPayload}`);
         const client = new _client_js__WEBPACK_IMPORTED_MODULE_1__/* .Client */ .K({
             status,
@@ -70677,10 +70664,6 @@ async function run() {
             text_on_cancel,
             title,
             only_mention_fail,
-            username,
-            icon_emoji,
-            icon_url,
-            channel,
         }, process.env.GITHUB_TOKEN, process.env.SLACK_WEBHOOK_URL);
         switch (status) {
             case 'success':

--- a/src/client.ts
+++ b/src/client.ts
@@ -12,10 +12,6 @@ export interface With {
   text_on_cancel: string;
   title: string;
   only_mention_fail: string;
-  username: string;
-  icon_emoji: string;
-  icon_url: string;
-  channel: string;
 }
 
 const groupMention = ['here', 'channel'];
@@ -76,14 +72,9 @@ export class Client {
 
   private async payloadTemplate() {
     const text = this.mentionText(this.with.mention);
-    const { username, icon_emoji, icon_url, channel } = this.with;
 
     return {
       text,
-      username,
-      icon_emoji,
-      icon_url,
-      channel,
       attachments: [
         {
           color: '',

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,10 +13,6 @@ async function run(): Promise<void> {
     const text_on_success = core.getInput('text_on_success');
     const text_on_fail = core.getInput('text_on_fail');
     const text_on_cancel = core.getInput('text_on_cancel');
-    const username = core.getInput('username');
-    const icon_emoji = core.getInput('icon_emoji');
-    const icon_url = core.getInput('icon_url');
-    const channel = core.getInput('channel');
     const rawPayload = core.getInput('payload');
 
     core.debug(`status: ${status}`);
@@ -27,10 +23,6 @@ async function run(): Promise<void> {
     core.debug(`text_on_success: ${text_on_success}`);
     core.debug(`text_on_fail: ${text_on_fail}`);
     core.debug(`text_on_cancel: ${text_on_cancel}`);
-    core.debug(`username: ${username}`);
-    core.debug(`icon_emoji: ${icon_emoji}`);
-    core.debug(`icon_url: ${icon_url}`);
-    core.debug(`channel: ${channel}`);
     core.debug(`rawPayload: ${rawPayload}`);
 
     const client = new Client(
@@ -43,10 +35,6 @@ async function run(): Promise<void> {
         text_on_cancel,
         title,
         only_mention_fail,
-        username,
-        icon_emoji,
-        icon_url,
-        channel,
       },
       process.env.GITHUB_TOKEN,
       process.env.SLACK_WEBHOOK_URL,


### PR DESCRIPTION
## Summary

Slack has phased out legacy custom-integration Incoming Webhooks (the admin toggle to create new ones is gone on most workspaces). This PR removes legacy-only inputs and updates docs/workflows accordingly.

**Base branch is `feature/upgrade-actions-github-v9`** (PR #51) — please merge that first.

## Breaking changes

The following inputs are removed because they only have an effect on legacy webhooks (Slack App webhooks ignore them at the API level):

- `username`
- `icon_emoji`
- `icon_url`
- `channel`

Users already on a Slack App webhook see no behavior change. Users still on a legacy webhook need to migrate — a migration guide is added to `README.md` (`Migrating from Legacy Incoming Webhook (v3 → v4)`).

## Other changes

- `action.yml` / `src/main.ts` / `src/client.ts`: drop the four removed inputs and related plumbing.
- `.github/workflows/slack-pre.yml` / `slack-mainline.yml`: remove the `Legacy Check` step and the `SLACK_LEGACY_WEBHOOK_URL_FOR_INTEGRATION_TEST` secret reference.
- `DEVELOPMENT.md`: remove legacy webhook setup section.
- `README.md`: remove legacy example/parameter table; add migration guide.

## Test plan

- [x] `npm run all` (build / format / lint / pack / test) passes
- [ ] Slack Pre integration workflow passes after merge to `pre`
- [ ] Slack Mainline integration workflow passes after merge to `main`

## Follow-up

A subsequent PR will bump the version to **v4.0.0** and update the `@v3` references in README/DEVELOPMENT to `@v4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)