### PR TITLE
ci: flip self-references from @v3 to @v4 (post-v4.0.0)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
           release_name: Release ${{ github.ref }}
           draft: false
           prerelease: false
-      - uses: sonots/slack-notice-action@v3
+      - uses: sonots/slack-notice-action@v4
         with:
           status: ${{ job.status }}
         env:

--- a/.github/workflows/slack-mainline.yml
+++ b/.github/workflows/slack-mainline.yml
@@ -10,35 +10,35 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Succeeded Check
-        uses: sonots/slack-notice-action@v3
+        uses: sonots/slack-notice-action@v4
         with:
           status: success
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_FOR_INTEGRATION_TEST }}
       - name: Failed Check
-        uses: sonots/slack-notice-action@v3
+        uses: sonots/slack-notice-action@v4
         with:
           status: failure
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_FOR_INTEGRATION_TEST }}
       - name: Cancelled Check
-        uses: sonots/slack-notice-action@v3
+        uses: sonots/slack-notice-action@v4
         with:
           status: cancelled
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_FOR_INTEGRATION_TEST }}
       - name: Check
-        uses: sonots/slack-notice-action@v3
+        uses: sonots/slack-notice-action@v4
         with:
           status: ${{ job.status }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_FOR_INTEGRATION_TEST }}
       - name: Custom Field Check
-        uses: sonots/slack-notice-action@v3
+        uses: sonots/slack-notice-action@v4
         with:
           status: custom
           payload: |
@@ -73,7 +73,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_FOR_INTEGRATION_TEST }}
       - name: Check
-        uses: sonots/slack-notice-action@v3
+        uses: sonots/slack-notice-action@v4
         with:
           status: ${{ job.status }}
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      - uses: sonots/slack-notice-action@v3
+      - uses: sonots/slack-notice-action@v4
         with:
           status: ${{ job.status }}
         env:


### PR DESCRIPTION
## Summary

Now that v4.0.0 is tagged and the `v4` branch is in place, flip the action's own CI self-references from `@v3` to `@v4`.

## Background

PR #53 (the v4.0.0 release prep PR) deliberately left `@v3` in place for these workflows because the `@v4` ref didn't exist yet. Trying to use it pre-release made `test.yml` fail with `Unable to resolve action sonots/slack-notice-action@v4`.

v4.0.0 is now released, so the action can safely reference its own current major version.

## Files

- `.github/workflows/test.yml`
- `.github/workflows/release.yml`
- `.github/workflows/slack-mainline.yml` (6 occurrences)

## Test plan

- [ ] CI passes (test.yml's final step now uses the freshly-tagged v4)
- [ ] After merge, `Slack Mainline` on main produces Slack notifications via `@v4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)