### PR TITLE
feat: link branch/tag on ref; replace ref/commit with PR field on PR events

### DIFF
--- a/.github/workflows/slack-pre.yml
+++ b/.github/workflows/slack-pre.yml
@@ -65,6 +65,36 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_FOR_INTEGRATION_TEST }}
+      - name: Intentional Failure (for failed_steps test)
+        id: intentional-failure
+        run: exit 1
+        continue-on-error: true
+      - name: Failed Steps Check
+        uses: sonots/slack-notice-action@pre
+        with:
+          status: failure
+          text_on_fail: 'failed_steps test: the intentional failure above should be listed in the failed_steps field'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_FOR_INTEGRATION_TEST }}
+      - name: Notice On Skip Check (should NOT post)
+        uses: sonots/slack-notice-action@pre
+        with:
+          status: success
+          notice_on: failure
+          text_on_success: 'YOU SHOULD NOT SEE THIS — notice_on=failure on success should skip'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_FOR_INTEGRATION_TEST }}
+      - name: Notice On Allow Check (should post)
+        uses: sonots/slack-notice-action@pre
+        with:
+          status: success
+          notice_on: success,failure
+          text_on_success: 'notice_on=success,failure → this success message should be visible'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_FOR_INTEGRATION_TEST }}
       - name: Check
         uses: sonots/slack-notice-action@pre
         with:

--- a/.github/workflows/slack-pre.yml
+++ b/.github/workflows/slack-pre.yml
@@ -24,6 +24,7 @@ jobs:
         uses: sonots/slack-notice-action@pre
         with:
           status: Success
+          text_on_success: ':white_check_mark: text_on_success — visible on success'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_FOR_INTEGRATION_TEST }}
@@ -32,6 +33,7 @@ jobs:
         with:
           status: Failure
           only_mention_fail: here
+          text_on_fail: ':rotating_light: text_on_fail — visible on failure'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_FOR_INTEGRATION_TEST }}
@@ -39,6 +41,7 @@ jobs:
         uses: sonots/slack-notice-action@pre
         with:
           status: Cancelled
+          text_on_cancel: ':warning: text_on_cancel — visible on cancellation'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_FOR_INTEGRATION_TEST }}
@@ -81,7 +84,7 @@ jobs:
         uses: sonots/slack-notice-action@pre
         with:
           status: failure
-          text_on_fail: 'failed_steps test: the failure-source job''s Intentional Failure step should appear in failed_steps'
+          text_on_fail: 'failed_steps test: the failure-source job''s Intentional Failure step should appear in workflow failed steps'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_FOR_INTEGRATION_TEST }}
@@ -94,12 +97,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_FOR_INTEGRATION_TEST }}
-      - name: Notice On Allow Check (should post)
+      - name: Notice On Failure Check (should post)
         uses: sonots/slack-notice-action@pre
         with:
-          status: success
-          notice_on: success,failure
-          text_on_success: 'notice_on=success,failure → this success message should be visible'
+          status: failure
+          notice_on: failure
+          text_on_fail: 'notice_on=failure on failure → this failure message should be visible'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_FOR_INTEGRATION_TEST }}

--- a/.github/workflows/slack-pre.yml
+++ b/.github/workflows/slack-pre.yml
@@ -5,20 +5,8 @@ on:
       - pre
 
 jobs:
-  failure-source:
-    # This job intentionally fails to provide a real `step.conclusion: failure`
-    # entry for the `failed_steps` integration check below. `continue-on-error`
-    # at job level lets the run still complete green overall.
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    steps:
-      - name: Intentional Failure (for failed_steps test)
-        run: exit 1
-
   notification:
     runs-on: ubuntu-latest
-    needs: failure-source
-    if: always()
     steps:
       - name: Succeeded Check
         uses: sonots/slack-notice-action@pre
@@ -77,32 +65,6 @@ jobs:
                 }]
               }]
             }
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_FOR_INTEGRATION_TEST }}
-      - name: Failed Steps Check
-        uses: sonots/slack-notice-action@pre
-        with:
-          status: failure
-          text_on_fail: 'failed_steps test: the failure-source job''s Intentional Failure step should appear in workflow failed steps'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_FOR_INTEGRATION_TEST }}
-      - name: Notice On Skip Check (should NOT post)
-        uses: sonots/slack-notice-action@pre
-        with:
-          status: success
-          notice_on: failure
-          text_on_success: 'YOU SHOULD NOT SEE THIS — notice_on=failure on success should skip'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_FOR_INTEGRATION_TEST }}
-      - name: Notice On Failure Check (should post)
-        uses: sonots/slack-notice-action@pre
-        with:
-          status: failure
-          notice_on: failure
-          text_on_fail: 'notice_on=failure on failure → this failure message should be visible'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_FOR_INTEGRATION_TEST }}

--- a/.github/workflows/slack-pre.yml
+++ b/.github/workflows/slack-pre.yml
@@ -5,8 +5,20 @@ on:
       - pre
 
 jobs:
+  failure-source:
+    # This job intentionally fails to provide a real `step.conclusion: failure`
+    # entry for the `failed_steps` integration check below. `continue-on-error`
+    # at job level lets the run still complete green overall.
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Intentional Failure (for failed_steps test)
+        run: exit 1
+
   notification:
     runs-on: ubuntu-latest
+    needs: failure-source
+    if: always()
     steps:
       - name: Succeeded Check
         uses: sonots/slack-notice-action@pre
@@ -65,15 +77,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_FOR_INTEGRATION_TEST }}
-      - name: Intentional Failure (for failed_steps test)
-        id: intentional-failure
-        run: exit 1
-        continue-on-error: true
       - name: Failed Steps Check
         uses: sonots/slack-notice-action@pre
         with:
           status: failure
-          text_on_fail: 'failed_steps test: the intentional failure above should be listed in the failed_steps field'
+          text_on_fail: 'failed_steps test: the failure-source job''s Intentional Failure step should appear in failed_steps'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_FOR_INTEGRATION_TEST }}

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ and arbitrary custom payloads.
 - [Input Parameters](#input-parameters)
 - [Environment Variables](#environment-variables)
 - [Custom Text and Mentions](#custom-text-and-mentions)
+- [Filter notifications by status](#filter-notifications-by-status)
+- [Message Fields](#message-fields)
 - [Custom Payload](#custom-payload)
 - [Screenshots](#screenshots)
 - [Slack App Setup](#slack-app-setup)
@@ -46,6 +48,7 @@ and arbitrary custom payloads.
 | `title`             | any string                                                                      | workflow name | Attachment title.                                                                                        |
 | `mention`           | <ul><li>`here`</li><li>`channel`</li><li>user ID (e.g. `U024BE7LH`)</li></ul>   | `''`          | Mention always if specified. Comma-separate for multiple users. See [Mentioning Users][mentioning-users]. |
 | `only_mention_fail` | same as `mention`                                                               | `''`          | Mention only on failure if specified.                                                                    |
+| `notice_on`         | comma-separated statuses (e.g. `failure`, `failure,cancelled`)                  | `''`          | If set, only notify when `status` matches. Empty means notify on every status (default).                |
 | `payload`           | JavaScript object literal                                                       | —             | **Required when `status: custom`.** Replaces the default message. See [Custom Payload](#custom-payload). |
 
 [mentioning-users]: https://api.slack.com/reference/surfaces/formatting#mentioning-users
@@ -78,6 +81,42 @@ fires when `status` is `failure`.
     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   if: always()
 ```
+
+## Filter notifications by status
+
+Use `notice_on` to skip statuses you do not care about. The most common
+setup is "only alert me on failure":
+
+```yaml
+- uses: sonots/slack-notice-action@v4
+  with:
+    status: ${{ job.status }}
+    notice_on: 'failure'
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+  if: always()
+```
+
+Pass a comma-separated list to allow multiple statuses, e.g.
+`notice_on: 'failure,cancelled'`. When `notice_on` is empty (the default),
+every status is delivered. `status: custom` always sends regardless.
+
+## Message Fields
+
+The default message includes the following fields:
+
+| Field           | Notes                                                                                    |
+| --------------- | ---------------------------------------------------------------------------------------- |
+| `repo`          | Repository link.                                                                         |
+| `branch` / `tag`| Derived from `GITHUB_REF`. Falls back to `ref` for refs like `refs/pull/.../merge`.      |
+| `commit`        | Commit SHA linked to GitHub.                                                             |
+| `diff`          | Compare URL (push events only — uses `payload.compare`).                                 |
+| `author`        | Commit author name and email.                                                            |
+| `message`       | Commit message. Merge-commit PR bodies are appended.                                     |
+| `pull_request`  | PR number, title, and link (`pull_request` / `pull_request_target` events only).         |
+| `workflow`      | Workflow name linked to the run.                                                         |
+| `failed_steps`  | Each failed step as `job > step` (only on `status: failure` when GitHub API is reachable).|
 
 ## Custom Payload
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ and arbitrary custom payloads.
 - [Input Parameters](#input-parameters)
 - [Environment Variables](#environment-variables)
 - [Custom Text and Mentions](#custom-text-and-mentions)
-- [Filter notifications by status](#filter-notifications-by-status)
 - [Message Fields](#message-fields)
 - [Custom Payload](#custom-payload)
 - [Screenshots](#screenshots)
@@ -48,7 +47,6 @@ and arbitrary custom payloads.
 | `title`             | any string                                                                      | workflow name | Attachment title.                                                                                        |
 | `mention`           | <ul><li>`here`</li><li>`channel`</li><li>user ID (e.g. `U024BE7LH`)</li></ul>   | `''`          | Mention always if specified. Comma-separate for multiple users. See [Mentioning Users][mentioning-users]. |
 | `only_mention_fail` | same as `mention`                                                               | `''`          | Mention only on failure if specified.                                                                    |
-| `notice_on`         | comma-separated statuses (e.g. `failure`, `failure,cancelled`)                  | `''`          | If set, only notify when `status` matches. Empty means notify on every status (default).                |
 | `payload`           | JavaScript object literal                                                       | —             | **Required when `status: custom`.** Replaces the default message. See [Custom Payload](#custom-payload). |
 
 [mentioning-users]: https://api.slack.com/reference/surfaces/formatting#mentioning-users
@@ -82,26 +80,6 @@ fires when `status` is `failure`.
   if: always()
 ```
 
-## Filter notifications by status
-
-Use `notice_on` to skip statuses you do not care about. The most common
-setup is "only alert me on failure":
-
-```yaml
-- uses: sonots/slack-notice-action@v4
-  with:
-    status: ${{ job.status }}
-    notice_on: 'failure'
-  env:
-    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-  if: always()
-```
-
-Pass a comma-separated list to allow multiple statuses, e.g.
-`notice_on: 'failure,cancelled'`. When `notice_on` is empty (the default),
-every status is delivered. `status: custom` always sends regardless.
-
 ## Message Fields
 
 The default message includes the following fields:
@@ -113,9 +91,7 @@ The default message includes the following fields:
 | `commit`        | Commit SHA linked to GitHub.                                                             |
 | `author`        | Commit author name and email.                                                            |
 | `message`       | Commit message. Merge-commit PR bodies are appended.                                     |
-| `pull_request`  | PR number, title, and link (`pull_request` / `pull_request_target` events only).         |
 | `workflow`      | Workflow name linked to the run.                                                         |
-| `workflow failed steps` | Each failed step as `job > step` (only on `status: failure` when GitHub API is reachable).|
 
 ## Custom Payload
 

--- a/README.md
+++ b/README.md
@@ -87,8 +87,9 @@ The default message includes the following fields:
 | Field           | Notes                                                                                    |
 | --------------- | ---------------------------------------------------------------------------------------- |
 | `repo`          | Repository link.                                                                         |
-| `ref`           | Raw ref string (e.g. `refs/heads/main`, `refs/tags/v1.0.0`) followed by a `branch` / `tag` link to `tree/<name>` on GitHub. Unusual refs (e.g. `refs/pull/.../merge`) appear as plain text with no link. |
-| `commit`        | Commit SHA linked to GitHub.                                                             |
+| `ref`           | Raw ref string (e.g. `refs/heads/main`, `refs/tags/v1.0.0`) followed by a `branch` / `tag` link to `tree/<name>` on GitHub. **Replaced by `pull request` on PR events.** |
+| `commit`        | Commit SHA linked to GitHub. **Hidden on PR events** (the PR link replaces it).          |
+| `pull request`  | PR title linked to the PR (only on `pull_request` / `pull_request_target` events; replaces `ref` and `commit`). |
 | `author`        | Commit author name and email.                                                            |
 | `message`       | Commit message. Merge-commit PR bodies are appended.                                     |
 | `workflow`      | Workflow name linked to the run.                                                         |

--- a/README.md
+++ b/README.md
@@ -109,9 +109,8 @@ The default message includes the following fields:
 | Field           | Notes                                                                                    |
 | --------------- | ---------------------------------------------------------------------------------------- |
 | `repo`          | Repository link.                                                                         |
-| `branch` / `tag`| Derived from `GITHUB_REF`. Falls back to `ref` for refs like `refs/pull/.../merge`.      |
+| `ref`           | Short branch/tag name linked to `tree/<name>` on GitHub. Raw ref for unusual refs (e.g. `refs/pull/.../merge`). |
 | `commit`        | Commit SHA linked to GitHub.                                                             |
-| `diff`          | Compare URL (push events only — uses `payload.compare`).                                 |
 | `author`        | Commit author name and email.                                                            |
 | `message`       | Commit message. Merge-commit PR bodies are appended.                                     |
 | `pull_request`  | PR number, title, and link (`pull_request` / `pull_request_target` events only).         |

--- a/README.md
+++ b/README.md
@@ -84,13 +84,17 @@ fires when `status` is `failure`.
 
 ## Message Anatomy
 
-Each notification is rendered as a Slack `attachment`: a colored
-sidebar block with a header (`title`), a list of `fields`, and a
-top-level text line that sits *above* the attachment.
+A notification is a Slack message with one colored `attachment`. The
+top-level **text line** (`mention` + `text_on_*` / `text`) sits
+**outside the attachment, above it** — it is just a regular Slack
+message text. The attachment is the boxed, color-bordered block
+underneath; it has its own `title`, `fields`, and `color`.
 
 ```
-[mentions] [top-level text]
-╭──[ title ]──────────────────────────
+@channel :tada: All checks passed!        ← message text (mention + text_on_*)
+╭─────────────────────────────
+│ My Workflow                              ← attachment title
+│
 │ repo
 │ owner/repo
 │
@@ -108,16 +112,26 @@ top-level text line that sits *above* the attachment.
 │
 │ workflow
 │ My Workflow
-╰──[ color ]──────────────────────────
+╰── (green sidebar) ─────────
 ```
 
-| Element        | Source                                                                       |
-| -------------- | ---------------------------------------------------------------------------- |
-| top-level text | `text_on_<status>` if set, else `text`, else a built-in default per status.  |
-| mentions       | `mention` always-on; `only_mention_fail` adds mentions only on `status: failure`. Rendered as `<!here>` / `<!channel>` / `<@user_id>` *inside* the top-level text line. |
-| `title`        | `title` input if set, else the GitHub workflow name.                         |
-| `fields`       | See [Message Fields](#message-fields) — layout differs between push events and PR events. |
-| `color`        | `good` (success) / `danger` (failure) / `warning` (cancelled).               |
+The YAML that produced the layout above:
+
+```yaml
+with:
+  status: success
+  mention: 'channel'                                   # → <!channel> in the text line
+  text_on_success: ':tada: All checks passed!'         # → body of the text line
+  title: 'My Workflow'                                 # → attachment title
+```
+
+| Input                              | Where it renders                                                                 |
+| ---------------------------------- | -------------------------------------------------------------------------------- |
+| `mention` / `only_mention_fail`    | **Text line** (above the attachment), as `<!here>` / `<!channel>` / `<@user_id>`. |
+| `text` / `text_on_<status>`        | **Text line**, after the mentions. `text_on_<status>` wins over `text`, which wins over a built-in default. |
+| `title`                            | **Attachment header** (the bold line inside the colored block). Defaults to the GitHub workflow name. |
+| `fields`                           | **Attachment body** — see [Message Fields](#message-fields). |
+| (status)                           | **Sidebar color**: `good` (success) / `danger` (failure) / `warning` (cancelled). |
 
 ### PR event layout
 
@@ -127,8 +141,10 @@ commit-`message`) are replaced with PR-centric equivalents so the
 notification points at the PR instead of the synthetic merge commit:
 
 ```
-[mentions] [top-level text]
-╭──[ title ]──────────────────────────
+@channel :tada: All checks passed!
+╭─────────────────────────────
+│ My Workflow
+│
 │ repo
 │ owner/repo
 │
@@ -143,7 +159,7 @@ notification points at the PR instead of the synthetic merge commit:
 │
 │ workflow
 │ My Workflow
-╰──[ color ]──────────────────────────
+╰── (green sidebar) ─────────
 ```
 
 Set `show_message: 'false'` to hide the `message` field on either

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ and arbitrary custom payloads.
 - [Input Parameters](#input-parameters)
 - [Environment Variables](#environment-variables)
 - [Custom Text and Mentions](#custom-text-and-mentions)
+- [Message Anatomy](#message-anatomy)
 - [Message Fields](#message-fields)
 - [Custom Payload](#custom-payload)
 - [Screenshots](#screenshots)
@@ -47,6 +48,7 @@ and arbitrary custom payloads.
 | `title`             | any string                                                                      | workflow name | Attachment title.                                                                                        |
 | `mention`           | <ul><li>`here`</li><li>`channel`</li><li>user ID (e.g. `U024BE7LH`)</li></ul>   | `''`          | Mention always if specified. Comma-separate for multiple users. See [Mentioning Users][mentioning-users]. |
 | `only_mention_fail` | same as `mention`                                                               | `''`          | Mention only on failure if specified.                                                                    |
+| `show_message`      | `'true'` / `'false'`                                                            | `'true'`      | Hide the `message` field. Useful when commit messages or PR bodies are long.                            |
 | `payload`           | JavaScript object literal                                                       | —             | **Required when `status: custom`.** Replaces the default message. See [Custom Payload](#custom-payload). |
 
 [mentioning-users]: https://api.slack.com/reference/surfaces/formatting#mentioning-users
@@ -79,6 +81,73 @@ fires when `status` is `failure`.
     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   if: always()
 ```
+
+## Message Anatomy
+
+Each notification is rendered as a Slack `attachment`: a colored
+sidebar block with a header (`title`), a list of `fields`, and a
+top-level text line that sits *above* the attachment.
+
+```
+[mentions] [top-level text]
+╭──[ title ]──────────────────────────
+│ repo
+│ owner/repo
+│
+│ ref
+│ refs/heads/main  branch
+│
+│ commit
+│ abc1234
+│
+│ author
+│ name<email>
+│
+│ message
+│ Commit message...
+│
+│ workflow
+│ My Workflow
+╰──[ color ]──────────────────────────
+```
+
+| Element        | Source                                                                       |
+| -------------- | ---------------------------------------------------------------------------- |
+| top-level text | `text_on_<status>` if set, else `text`, else a built-in default per status.  |
+| mentions       | `mention` always-on; `only_mention_fail` adds mentions only on `status: failure`. Rendered as `<!here>` / `<!channel>` / `<@user_id>` *inside* the top-level text line. |
+| `title`        | `title` input if set, else the GitHub workflow name.                         |
+| `fields`       | See [Message Fields](#message-fields) — layout differs between push events and PR events. |
+| `color`        | `good` (success) / `danger` (failure) / `warning` (cancelled).               |
+
+### PR event layout
+
+On `pull_request` and `pull_request_target` events, the four
+commit-derived fields (`ref`, `commit`, commit-`author`,
+commit-`message`) are replaced with PR-centric equivalents so the
+notification points at the PR instead of the synthetic merge commit:
+
+```
+[mentions] [top-level text]
+╭──[ title ]──────────────────────────
+│ repo
+│ owner/repo
+│
+│ pull_request
+│ <PR title>             ← link to the PR
+│
+│ author
+│ <pr-creator-login>     ← link to the user's profile
+│
+│ message
+│ <PR description body>
+│
+│ workflow
+│ My Workflow
+╰──[ color ]──────────────────────────
+```
+
+Set `show_message: 'false'` to hide the `message` field on either
+layout when the body tends to be long.
 
 ## Message Fields
 

--- a/README.md
+++ b/README.md
@@ -109,13 +109,13 @@ The default message includes the following fields:
 | Field           | Notes                                                                                    |
 | --------------- | ---------------------------------------------------------------------------------------- |
 | `repo`          | Repository link.                                                                         |
-| `ref`           | Short branch/tag name linked to `tree/<name>` on GitHub. Raw ref for unusual refs (e.g. `refs/pull/.../merge`). |
+| `ref`           | Raw ref string (e.g. `refs/heads/main`, `refs/tags/v1.0.0`) followed by a `branch` / `tag` link to `tree/<name>` on GitHub. Unusual refs (e.g. `refs/pull/.../merge`) appear as plain text with no link. |
 | `commit`        | Commit SHA linked to GitHub.                                                             |
 | `author`        | Commit author name and email.                                                            |
 | `message`       | Commit message. Merge-commit PR bodies are appended.                                     |
 | `pull_request`  | PR number, title, and link (`pull_request` / `pull_request_target` events only).         |
 | `workflow`      | Workflow name linked to the run.                                                         |
-| `failed_steps`  | Each failed step as `job > step` (only on `status: failure` when GitHub API is reachable).|
+| `workflow failed steps` | Each failed step as `job > step` (only on `status: failure` when GitHub API is reachable).|
 
 ## Custom Payload
 

--- a/README.md
+++ b/README.md
@@ -82,17 +82,31 @@ fires when `status` is `failure`.
 
 ## Message Fields
 
-The default message includes the following fields:
+The default message has two layouts depending on the event:
 
-| Field           | Notes                                                                                    |
-| --------------- | ---------------------------------------------------------------------------------------- |
-| `repo`          | Repository link.                                                                         |
-| `ref`           | Raw ref string (e.g. `refs/heads/main`, `refs/tags/v1.0.0`) followed by a `branch` / `tag` link to `tree/<name>` on GitHub. **Replaced by `pull request` on PR events.** |
-| `commit`        | Commit SHA linked to GitHub. **Hidden on PR events** (the PR link replaces it).          |
-| `pull request`  | PR title linked to the PR (only on `pull_request` / `pull_request_target` events; replaces `ref` and `commit`). |
-| `author`        | Commit author name and email.                                                            |
-| `message`       | Commit message. Merge-commit PR bodies are appended.                                     |
-| `workflow`      | Workflow name linked to the run.                                                         |
+**Push / tag / other non-PR events**
+
+| Field      | Notes                                                                                  |
+| ---------- | -------------------------------------------------------------------------------------- |
+| `repo`     | Repository link.                                                                       |
+| `ref`      | Raw ref string (e.g. `refs/heads/main`, `refs/tags/v1.0.0`) followed by a `branch` / `tag` link to `tree/<name>` on GitHub. |
+| `commit`   | Commit SHA linked to GitHub.                                                           |
+| `author`   | Commit author name and email.                                                          |
+| `message`  | Commit message. Merge-commit PR bodies are appended.                                   |
+| `workflow` | Workflow name linked to the run.                                                       |
+
+**`pull_request` / `pull_request_target` events**
+
+`ref`, `commit`, the commit author, and the commit message are replaced
+with PR-centric equivalents:
+
+| Field          | Notes                                              |
+| -------------- | -------------------------------------------------- |
+| `repo`         | Repository link.                                   |
+| `pull_request` | PR title linked to the PR.                         |
+| `author`       | PR creator's GitHub login, linked to their profile.|
+| `message`      | PR description (`pull_request.body`).              |
+| `workflow`     | Workflow name linked to the run.                   |
 
 ## Custom Payload
 

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,11 @@ inputs:
   text:
     description: You can overwrite text.
     default: ''
+  notice_on:
+    description: |
+      Comma-separated list of statuses to notify on. e.g. `failure`,
+      `failure,cancelled`. Default is empty, which notifies on all statuses.
+    default: ''
 runs:
   using: node24
   main: dist/index.js

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,12 @@ inputs:
   text_on_cancel:
     description: Override text on cancellation only. Wins over `text`.
     default: ''
+  show_message:
+    description: |
+      Show the `message` field (commit message on push events, PR body
+      on PR events). Set to `'false'` to hide it when the message tends
+      to be long. Default is to show.
+    default: ''
 runs:
   using: node24
   main: dist/index.js

--- a/action.yml
+++ b/action.yml
@@ -33,11 +33,6 @@ inputs:
   text_on_cancel:
     description: Override text on cancellation only. Wins over `text`.
     default: ''
-  notice_on:
-    description: |
-      Comma-separated list of statuses to notify on. e.g. `failure`,
-      `failure,cancelled`. Default is empty, which notifies on all statuses.
-    default: ''
 runs:
   using: node24
   main: dist/index.js

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,15 @@ inputs:
   text:
     description: You can overwrite text.
     default: ''
+  text_on_success:
+    description: Override text on success only. Wins over `text`.
+    default: ''
+  text_on_fail:
+    description: Override text on failure only. Wins over `text`.
+    default: ''
+  text_on_cancel:
+    description: Override text on cancellation only. Wins over `text`.
+    default: ''
   notice_on:
     description: |
       Comma-separated list of statuses to notify on. e.g. `failure`,

--- a/dist/index.js
+++ b/dist/index.js
@@ -70389,6 +70389,18 @@ class Client {
         }
         this.webhook = new dist/* IncomingWebhook */.iv(webhookUrl);
     }
+    shouldNotice(status) {
+        const raw = this.with.notice_on;
+        if (raw === '')
+            return true;
+        const allowed = raw
+            .split(',')
+            .map(s => s.trim().toLowerCase())
+            .filter(s => s !== '');
+        if (allowed.length === 0)
+            return true;
+        return allowed.includes(status.toLowerCase());
+    }
     async success() {
         const template = await this.payloadTemplate();
         template.attachments[0].color = 'good';
@@ -70440,22 +70452,19 @@ class Client {
         const { author } = commit.data.commit;
         const authorValue = author ? `${author.name}<${author.email}>` : 'unknown';
         const message = await this.message(commit.data.commit.message);
-        return [
+        const fields = [
             {
                 title: 'repo',
                 value: this.repositoryLink,
                 short: false,
             },
-            {
-                title: 'ref',
-                value: github_context.ref,
-                short: false,
-            },
+            this.refField,
             {
                 title: 'commit',
                 value: this.commitLink,
                 short: false,
             },
+            this.compareField,
             {
                 title: 'author',
                 value: authorValue,
@@ -70466,12 +70475,15 @@ class Client {
                 value: message,
                 short: false,
             },
+            this.pullRequestField,
             {
                 title: 'workflow',
                 value: this.workflowLink,
                 short: false,
             },
+            await this.failedStepsField(),
         ];
+        return fields.filter((f) => f !== null);
     }
     get textSuccess() {
         if (this.with.text_on_success !== '') {
@@ -70514,6 +70526,75 @@ class Client {
     get repositoryLink() {
         const { owner, repo } = github_context.repo;
         return `<https://github.com/${owner}/${repo}|${owner}/${repo}>`;
+    }
+    get refField() {
+        const ref = github_context.ref;
+        const branchMatch = ref.match(/^refs\/heads\/(.+)$/);
+        if (branchMatch) {
+            return { title: 'branch', value: branchMatch[1], short: false };
+        }
+        const tagMatch = ref.match(/^refs\/tags\/(.+)$/);
+        if (tagMatch) {
+            return { title: 'tag', value: tagMatch[1], short: false };
+        }
+        return { title: 'ref', value: ref, short: false };
+    }
+    get compareField() {
+        const compare = github_context.payload.compare;
+        if (typeof compare !== 'string' || compare === '')
+            return null;
+        return { title: 'diff', value: `<${compare}|compare>`, short: false };
+    }
+    get pullRequestField() {
+        const pr = github_context.payload.pull_request;
+        if (!pr)
+            return null;
+        const number = pr.number;
+        const title = pr.title ?? '';
+        const url = pr.html_url ?? '';
+        if (!url)
+            return null;
+        return {
+            title: 'pull_request',
+            value: `<${url}|#${number}> ${title}`,
+            short: false,
+        };
+    }
+    async failedStepsField() {
+        if (this.with.status.toLowerCase() !== 'failure')
+            return null;
+        if (this.octokit === undefined)
+            return null;
+        const { owner, repo } = github_context.repo;
+        try {
+            const { data } = await this.octokit.rest.actions.listJobsForWorkflowRun({
+                owner,
+                repo,
+                run_id: parseInt(this.runId, 10),
+            });
+            const failed = [];
+            for (const job of data.jobs) {
+                if (job.conclusion !== 'failure')
+                    continue;
+                const steps = job.steps ?? [];
+                for (const step of steps) {
+                    if (step.conclusion === 'failure') {
+                        failed.push(`${job.name} > ${step.name}`);
+                    }
+                }
+            }
+            if (failed.length === 0)
+                return null;
+            return {
+                title: 'failed_steps',
+                value: failed.map(s => `• ${s}`).join('\n'),
+                short: false,
+            };
+        }
+        catch (e) {
+            core.debug(`failedStepsField error: ${e instanceof Error ? e.message : String(e)}`);
+            return null;
+        }
     }
     async message(message) {
         if (this.octokit === undefined) {
@@ -70645,6 +70726,7 @@ async function run() {
         const text_on_success = _actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput('text_on_success');
         const text_on_fail = _actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput('text_on_fail');
         const text_on_cancel = _actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput('text_on_cancel');
+        const notice_on = _actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput('notice_on');
         const rawPayload = _actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput('payload');
         _actions_core__WEBPACK_IMPORTED_MODULE_0__.debug(`status: ${status}`);
         _actions_core__WEBPACK_IMPORTED_MODULE_0__.debug(`mention: ${mention}`);
@@ -70654,6 +70736,7 @@ async function run() {
         _actions_core__WEBPACK_IMPORTED_MODULE_0__.debug(`text_on_success: ${text_on_success}`);
         _actions_core__WEBPACK_IMPORTED_MODULE_0__.debug(`text_on_fail: ${text_on_fail}`);
         _actions_core__WEBPACK_IMPORTED_MODULE_0__.debug(`text_on_cancel: ${text_on_cancel}`);
+        _actions_core__WEBPACK_IMPORTED_MODULE_0__.debug(`notice_on: ${notice_on}`);
         _actions_core__WEBPACK_IMPORTED_MODULE_0__.debug(`rawPayload: ${rawPayload}`);
         const client = new _client_js__WEBPACK_IMPORTED_MODULE_1__/* .Client */ .K({
             status,
@@ -70664,7 +70747,12 @@ async function run() {
             text_on_cancel,
             title,
             only_mention_fail,
+            notice_on,
         }, process.env.GITHUB_TOKEN, process.env.SLACK_WEBHOOK_URL);
+        if (status !== 'custom' && !client.shouldNotice(status)) {
+            _actions_core__WEBPACK_IMPORTED_MODULE_0__.info(`Skipped: status "${status}" not in notice_on "${notice_on}"`);
+            return;
+        }
         switch (status) {
             case 'success':
                 await client.send(await client.success());

--- a/dist/index.js
+++ b/dist/index.js
@@ -70389,18 +70389,6 @@ class Client {
         }
         this.webhook = new dist/* IncomingWebhook */.iv(webhookUrl);
     }
-    shouldNotice(status) {
-        const raw = this.with.notice_on;
-        if (raw === '')
-            return true;
-        const allowed = raw
-            .split(',')
-            .map(s => s.trim().toLowerCase())
-            .filter(s => s !== '');
-        if (allowed.length === 0)
-            return true;
-        return allowed.includes(status.toLowerCase());
-    }
     async success() {
         const template = await this.payloadTemplate();
         template.attachments[0].color = 'good';
@@ -70452,7 +70440,7 @@ class Client {
         const { author } = commit.data.commit;
         const authorValue = author ? `${author.name}<${author.email}>` : 'unknown';
         const message = await this.message(commit.data.commit.message);
-        const fields = [
+        return [
             {
                 title: 'repo',
                 value: this.repositoryLink,
@@ -70474,15 +70462,12 @@ class Client {
                 value: message,
                 short: false,
             },
-            this.pullRequestField,
             {
                 title: 'workflow',
                 value: this.workflowLink,
                 short: false,
             },
-            await this.failedStepsField(),
         ];
-        return fields.filter((f) => f !== null);
     }
     get textSuccess() {
         if (this.with.text_on_success !== '') {
@@ -70542,58 +70527,6 @@ class Client {
             return { title: 'ref', value: `${ref} ${link}`, short: false };
         }
         return { title: 'ref', value: ref, short: false };
-    }
-    get pullRequestField() {
-        const pr = github_context.payload.pull_request;
-        if (!pr)
-            return null;
-        const number = pr.number;
-        const title = pr.title ?? '';
-        const url = pr.html_url ?? '';
-        if (!url)
-            return null;
-        return {
-            title: 'pull_request',
-            value: `<${url}|#${number}> ${title}`,
-            short: false,
-        };
-    }
-    async failedStepsField() {
-        if (this.with.status.toLowerCase() !== 'failure')
-            return null;
-        if (this.octokit === undefined)
-            return null;
-        const { owner, repo } = github_context.repo;
-        try {
-            const { data } = await this.octokit.rest.actions.listJobsForWorkflowRun({
-                owner,
-                repo,
-                run_id: parseInt(this.runId, 10),
-            });
-            // Don't filter by job.conclusion: when this action runs, the
-            // current job's conclusion is still null. Scan all steps and
-            // pick whichever ones report conclusion === 'failure'.
-            const failed = [];
-            for (const job of data.jobs) {
-                const steps = job.steps ?? [];
-                for (const step of steps) {
-                    if (step.conclusion === 'failure') {
-                        failed.push(`${job.name} > ${step.name}`);
-                    }
-                }
-            }
-            if (failed.length === 0)
-                return null;
-            return {
-                title: 'workflow failed steps',
-                value: failed.map(s => `• ${s}`).join('\n'),
-                short: false,
-            };
-        }
-        catch (e) {
-            core.debug(`failedStepsField error: ${e instanceof Error ? e.message : String(e)}`);
-            return null;
-        }
     }
     async message(message) {
         if (this.octokit === undefined) {
@@ -70725,7 +70658,6 @@ async function run() {
         const text_on_success = _actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput('text_on_success');
         const text_on_fail = _actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput('text_on_fail');
         const text_on_cancel = _actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput('text_on_cancel');
-        const notice_on = _actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput('notice_on');
         const rawPayload = _actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput('payload');
         _actions_core__WEBPACK_IMPORTED_MODULE_0__.debug(`status: ${status}`);
         _actions_core__WEBPACK_IMPORTED_MODULE_0__.debug(`mention: ${mention}`);
@@ -70735,7 +70667,6 @@ async function run() {
         _actions_core__WEBPACK_IMPORTED_MODULE_0__.debug(`text_on_success: ${text_on_success}`);
         _actions_core__WEBPACK_IMPORTED_MODULE_0__.debug(`text_on_fail: ${text_on_fail}`);
         _actions_core__WEBPACK_IMPORTED_MODULE_0__.debug(`text_on_cancel: ${text_on_cancel}`);
-        _actions_core__WEBPACK_IMPORTED_MODULE_0__.debug(`notice_on: ${notice_on}`);
         _actions_core__WEBPACK_IMPORTED_MODULE_0__.debug(`rawPayload: ${rawPayload}`);
         const client = new _client_js__WEBPACK_IMPORTED_MODULE_1__/* .Client */ .K({
             status,
@@ -70746,12 +70677,7 @@ async function run() {
             text_on_cancel,
             title,
             only_mention_fail,
-            notice_on,
         }, process.env.GITHUB_TOKEN, process.env.SLACK_WEBHOOK_URL);
-        if (status !== 'custom' && !client.shouldNotice(status)) {
-            _actions_core__WEBPACK_IMPORTED_MODULE_0__.info(`Skipped: status "${status}" not in notice_on "${notice_on}"`);
-            return;
-        }
         switch (status) {
             case 'success':
                 await client.send(await client.success());

--- a/dist/index.js
+++ b/dist/index.js
@@ -70427,6 +70427,60 @@ class Client {
         };
     }
     async fields() {
+        const fields = [
+            {
+                title: 'repo',
+                value: this.repositoryLink,
+                short: false,
+            },
+        ];
+        const prFields = this.pullRequestFields;
+        if (prFields) {
+            fields.push(...prFields);
+        }
+        else {
+            fields.push(...(await this.commitFields()));
+        }
+        fields.push({
+            title: 'workflow',
+            value: this.workflowLink,
+            short: false,
+        });
+        return fields;
+    }
+    get pullRequestFields() {
+        const pr = github_context.payload.pull_request;
+        if (!pr)
+            return null;
+        const url = pr.html_url;
+        const title = pr.title;
+        if (!url || !title)
+            return null;
+        const login = pr.user?.login;
+        const userUrl = pr.user?.html_url;
+        let authorValue = 'unknown';
+        if (login) {
+            authorValue = userUrl ? `<${userUrl}|${login}>` : login;
+        }
+        return [
+            {
+                title: 'pull_request',
+                value: `<${url}|${title}>`,
+                short: false,
+            },
+            {
+                title: 'author',
+                value: authorValue,
+                short: false,
+            },
+            {
+                title: 'message',
+                value: pr.body ?? '',
+                short: false,
+            },
+        ];
+    }
+    async commitFields() {
         if (this.octokit === undefined) {
             throw Error('Specify secrets.GITHUB_TOKEN');
         }
@@ -70440,53 +70494,24 @@ class Client {
         const { author } = commit.data.commit;
         const authorValue = author ? `${author.name}<${author.email}>` : 'unknown';
         const message = await this.message(commit.data.commit.message);
-        const fields = [
+        return [
+            this.refField,
             {
-                title: 'repo',
-                value: this.repositoryLink,
-                short: false,
-            },
-        ];
-        const prField = this.pullRequestField;
-        if (prField) {
-            fields.push(prField);
-        }
-        else {
-            fields.push(this.refField);
-            fields.push({
                 title: 'commit',
                 value: this.commitLink,
                 short: false,
-            });
-        }
-        fields.push({
-            title: 'author',
-            value: authorValue,
-            short: false,
-        }, {
-            title: 'message',
-            value: message,
-            short: false,
-        }, {
-            title: 'workflow',
-            value: this.workflowLink,
-            short: false,
-        });
-        return fields;
-    }
-    get pullRequestField() {
-        const pr = github_context.payload.pull_request;
-        if (!pr)
-            return null;
-        const url = pr.html_url;
-        const title = pr.title;
-        if (!url || !title)
-            return null;
-        return {
-            title: 'pull request',
-            value: `<${url}|${title}>`,
-            short: false,
-        };
+            },
+            {
+                title: 'author',
+                value: authorValue,
+                short: false,
+            },
+            {
+                title: 'message',
+                value: message,
+                short: false,
+            },
+        ];
     }
     get textSuccess() {
         if (this.with.text_on_success !== '') {

--- a/dist/index.js
+++ b/dist/index.js
@@ -70464,7 +70464,6 @@ class Client {
                 value: this.commitLink,
                 short: false,
             },
-            this.compareField,
             {
                 title: 'author',
                 value: authorValue,
@@ -70529,21 +70528,17 @@ class Client {
     }
     get refField() {
         const ref = github_context.ref;
-        const branchMatch = ref.match(/^refs\/heads\/(.+)$/);
-        if (branchMatch) {
-            return { title: 'branch', value: branchMatch[1], short: false };
-        }
-        const tagMatch = ref.match(/^refs\/tags\/(.+)$/);
-        if (tagMatch) {
-            return { title: 'tag', value: tagMatch[1], short: false };
+        const { owner, repo } = github_context.repo;
+        const m = ref.match(/^refs\/(?:heads|tags)\/(.+)$/);
+        if (m) {
+            const name = m[1];
+            return {
+                title: 'ref',
+                value: `<https://github.com/${owner}/${repo}/tree/${name}|${name}>`,
+                short: false,
+            };
         }
         return { title: 'ref', value: ref, short: false };
-    }
-    get compareField() {
-        const compare = github_context.payload.compare;
-        if (typeof compare !== 'string' || compare === '')
-            return null;
-        return { title: 'diff', value: `<${compare}|compare>`, short: false };
     }
     get pullRequestField() {
         const pr = github_context.payload.pull_request;
@@ -70572,10 +70567,11 @@ class Client {
                 repo,
                 run_id: parseInt(this.runId, 10),
             });
+            // Don't filter by job.conclusion: when this action runs, the
+            // current job's conclusion is still null. Scan all steps and
+            // pick whichever ones report conclusion === 'failure'.
             const failed = [];
             for (const job of data.jobs) {
-                if (job.conclusion !== 'failure')
-                    continue;
                 const steps = job.steps ?? [];
                 for (const step of steps) {
                     if (step.conclusion === 'failure') {

--- a/dist/index.js
+++ b/dist/index.js
@@ -70440,34 +70440,53 @@ class Client {
         const { author } = commit.data.commit;
         const authorValue = author ? `${author.name}<${author.email}>` : 'unknown';
         const message = await this.message(commit.data.commit.message);
-        return [
+        const fields = [
             {
                 title: 'repo',
                 value: this.repositoryLink,
                 short: false,
             },
-            this.refField,
-            {
+        ];
+        const prField = this.pullRequestField;
+        if (prField) {
+            fields.push(prField);
+        }
+        else {
+            fields.push(this.refField);
+            fields.push({
                 title: 'commit',
                 value: this.commitLink,
                 short: false,
-            },
-            {
-                title: 'author',
-                value: authorValue,
-                short: false,
-            },
-            {
-                title: 'message',
-                value: message,
-                short: false,
-            },
-            {
-                title: 'workflow',
-                value: this.workflowLink,
-                short: false,
-            },
-        ];
+            });
+        }
+        fields.push({
+            title: 'author',
+            value: authorValue,
+            short: false,
+        }, {
+            title: 'message',
+            value: message,
+            short: false,
+        }, {
+            title: 'workflow',
+            value: this.workflowLink,
+            short: false,
+        });
+        return fields;
+    }
+    get pullRequestField() {
+        const pr = github_context.payload.pull_request;
+        if (!pr)
+            return null;
+        const url = pr.html_url;
+        const title = pr.title;
+        if (!url || !title)
+            return null;
+        return {
+            title: 'pull request',
+            value: `<${url}|${title}>`,
+            short: false,
+        };
     }
     get textSuccess() {
         if (this.with.text_on_success !== '') {

--- a/dist/index.js
+++ b/dist/index.js
@@ -70448,6 +70448,9 @@ class Client {
         });
         return fields;
     }
+    get showMessage() {
+        return this.with.show_message.toLowerCase() !== 'false';
+    }
     get pullRequestFields() {
         const pr = github_context.payload.pull_request;
         if (!pr)
@@ -70462,7 +70465,7 @@ class Client {
         if (login) {
             authorValue = userUrl ? `<${userUrl}|${login}>` : login;
         }
-        return [
+        const fields = [
             {
                 title: 'pull_request',
                 value: `<${url}|${title}>`,
@@ -70473,12 +70476,15 @@ class Client {
                 value: authorValue,
                 short: false,
             },
-            {
+        ];
+        if (this.showMessage) {
+            fields.push({
                 title: 'message',
                 value: pr.body ?? '',
                 short: false,
-            },
-        ];
+            });
+        }
+        return fields;
     }
     async commitFields() {
         if (this.octokit === undefined) {
@@ -70493,8 +70499,7 @@ class Client {
         });
         const { author } = commit.data.commit;
         const authorValue = author ? `${author.name}<${author.email}>` : 'unknown';
-        const message = await this.message(commit.data.commit.message);
-        return [
+        const fields = [
             this.refField,
             {
                 title: 'commit',
@@ -70506,12 +70511,16 @@ class Client {
                 value: authorValue,
                 short: false,
             },
-            {
+        ];
+        if (this.showMessage) {
+            const message = await this.message(commit.data.commit.message);
+            fields.push({
                 title: 'message',
                 value: message,
                 short: false,
-            },
-        ];
+            });
+        }
+        return fields;
     }
     get textSuccess() {
         if (this.with.text_on_success !== '') {
@@ -70702,6 +70711,7 @@ async function run() {
         const text_on_success = _actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput('text_on_success');
         const text_on_fail = _actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput('text_on_fail');
         const text_on_cancel = _actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput('text_on_cancel');
+        const show_message = _actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput('show_message');
         const rawPayload = _actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput('payload');
         _actions_core__WEBPACK_IMPORTED_MODULE_0__.debug(`status: ${status}`);
         _actions_core__WEBPACK_IMPORTED_MODULE_0__.debug(`mention: ${mention}`);
@@ -70711,6 +70721,7 @@ async function run() {
         _actions_core__WEBPACK_IMPORTED_MODULE_0__.debug(`text_on_success: ${text_on_success}`);
         _actions_core__WEBPACK_IMPORTED_MODULE_0__.debug(`text_on_fail: ${text_on_fail}`);
         _actions_core__WEBPACK_IMPORTED_MODULE_0__.debug(`text_on_cancel: ${text_on_cancel}`);
+        _actions_core__WEBPACK_IMPORTED_MODULE_0__.debug(`show_message: ${show_message}`);
         _actions_core__WEBPACK_IMPORTED_MODULE_0__.debug(`rawPayload: ${rawPayload}`);
         const client = new _client_js__WEBPACK_IMPORTED_MODULE_1__/* .Client */ .K({
             status,
@@ -70721,6 +70732,7 @@ async function run() {
             text_on_cancel,
             title,
             only_mention_fail,
+            show_message,
         }, process.env.GITHUB_TOKEN, process.env.SLACK_WEBHOOK_URL);
         switch (status) {
             case 'success':

--- a/dist/index.js
+++ b/dist/index.js
@@ -70529,14 +70529,17 @@ class Client {
     get refField() {
         const ref = github_context.ref;
         const { owner, repo } = github_context.repo;
-        const m = ref.match(/^refs\/(?:heads|tags)\/(.+)$/);
-        if (m) {
-            const name = m[1];
-            return {
-                title: 'ref',
-                value: `<https://github.com/${owner}/${repo}/tree/${name}|${name}>`,
-                short: false,
-            };
+        const branchMatch = ref.match(/^refs\/heads\/(.+)$/);
+        if (branchMatch) {
+            const name = branchMatch[1];
+            const link = `<https://github.com/${owner}/${repo}/tree/${name}|branch>`;
+            return { title: 'ref', value: `${ref} ${link}`, short: false };
+        }
+        const tagMatch = ref.match(/^refs\/tags\/(.+)$/);
+        if (tagMatch) {
+            const name = tagMatch[1];
+            const link = `<https://github.com/${owner}/${repo}/tree/${name}|tag>`;
+            return { title: 'ref', value: `${ref} ${link}`, short: false };
         }
         return { title: 'ref', value: ref, short: false };
     }
@@ -70582,7 +70585,7 @@ class Client {
             if (failed.length === 0)
                 return null;
             return {
-                title: 'failed_steps',
+                title: 'workflow failed steps',
                 value: failed.map(s => `• ${s}`).join('\n'),
                 short: false,
             };

--- a/src/client.ts
+++ b/src/client.ts
@@ -12,7 +12,6 @@ export interface With {
   text_on_cancel: string;
   title: string;
   only_mention_fail: string;
-  notice_on: string;
 }
 
 interface Field {
@@ -44,17 +43,6 @@ export class Client {
       throw new Error('Specify secrets.SLACK_WEBHOOK_URL');
     }
     this.webhook = new IncomingWebhook(webhookUrl);
-  }
-
-  shouldNotice(status: string): boolean {
-    const raw = this.with.notice_on;
-    if (raw === '') return true;
-    const allowed = raw
-      .split(',')
-      .map(s => s.trim().toLowerCase())
-      .filter(s => s !== '');
-    if (allowed.length === 0) return true;
-    return allowed.includes(status.toLowerCase());
   }
 
   async success() {
@@ -118,7 +106,7 @@ export class Client {
     const authorValue = author ? `${author.name}<${author.email}>` : 'unknown';
     const message = await this.message(commit.data.commit.message);
 
-    const fields: Array<Field | null> = [
+    return [
       {
         title: 'repo',
         value: this.repositoryLink,
@@ -140,16 +128,12 @@ export class Client {
         value: message,
         short: false,
       },
-      this.pullRequestField,
       {
         title: 'workflow',
         value: this.workflowLink,
         short: false,
       },
-      await this.failedStepsField(),
     ];
-
-    return fields.filter((f): f is Field => f !== null);
   }
 
   private get textSuccess() {
@@ -218,56 +202,6 @@ export class Client {
       return { title: 'ref', value: `${ref} ${link}`, short: false };
     }
     return { title: 'ref', value: ref, short: false };
-  }
-
-  private get pullRequestField(): Field | null {
-    const pr = github.context.payload.pull_request;
-    if (!pr) return null;
-    const number = pr.number;
-    const title = (pr as { title?: string }).title ?? '';
-    const url = (pr as { html_url?: string }).html_url ?? '';
-    if (!url) return null;
-    return {
-      title: 'pull_request',
-      value: `<${url}|#${number}> ${title}`,
-      short: false,
-    };
-  }
-
-  private async failedStepsField(): Promise<Field | null> {
-    if (this.with.status.toLowerCase() !== 'failure') return null;
-    if (this.octokit === undefined) return null;
-    const { owner, repo } = github.context.repo;
-    try {
-      const { data } = await this.octokit.rest.actions.listJobsForWorkflowRun({
-        owner,
-        repo,
-        run_id: parseInt(this.runId, 10),
-      });
-      // Don't filter by job.conclusion: when this action runs, the
-      // current job's conclusion is still null. Scan all steps and
-      // pick whichever ones report conclusion === 'failure'.
-      const failed: string[] = [];
-      for (const job of data.jobs) {
-        const steps = job.steps ?? [];
-        for (const step of steps) {
-          if (step.conclusion === 'failure') {
-            failed.push(`${job.name} > ${step.name}`);
-          }
-        }
-      }
-      if (failed.length === 0) return null;
-      return {
-        title: 'workflow failed steps',
-        value: failed.map(s => `• ${s}`).join('\n'),
-        short: false,
-      };
-    } catch (e) {
-      core.debug(
-        `failedStepsField error: ${e instanceof Error ? e.message : String(e)}`,
-      );
-      return null;
-    }
   }
 
   private async message(message: string) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -12,6 +12,7 @@ export interface With {
   text_on_cancel: string;
   title: string;
   only_mention_fail: string;
+  show_message: string;
 }
 
 interface Field {
@@ -116,6 +117,10 @@ export class Client {
     return fields;
   }
 
+  private get showMessage(): boolean {
+    return this.with.show_message.toLowerCase() !== 'false';
+  }
+
   private get pullRequestFields(): Field[] | null {
     const pr = github.context.payload.pull_request as
       | {
@@ -137,7 +142,7 @@ export class Client {
       authorValue = userUrl ? `<${userUrl}|${login}>` : login;
     }
 
-    return [
+    const fields: Field[] = [
       {
         title: 'pull_request',
         value: `<${url}|${title}>`,
@@ -148,12 +153,15 @@ export class Client {
         value: authorValue,
         short: false,
       },
-      {
+    ];
+    if (this.showMessage) {
+      fields.push({
         title: 'message',
         value: pr.body ?? '',
         short: false,
-      },
-    ];
+      });
+    }
+    return fields;
   }
 
   private async commitFields(): Promise<Field[]> {
@@ -169,9 +177,8 @@ export class Client {
     });
     const { author } = commit.data.commit;
     const authorValue = author ? `${author.name}<${author.email}>` : 'unknown';
-    const message = await this.message(commit.data.commit.message);
 
-    return [
+    const fields: Field[] = [
       this.refField,
       {
         title: 'commit',
@@ -183,12 +190,16 @@ export class Client {
         value: authorValue,
         short: false,
       },
-      {
+    ];
+    if (this.showMessage) {
+      const message = await this.message(commit.data.commit.message);
+      fields.push({
         title: 'message',
         value: message,
         short: false,
-      },
-    ];
+      });
+    }
+    return fields;
   }
 
   private get textSuccess() {

--- a/src/client.ts
+++ b/src/client.ts
@@ -106,18 +106,27 @@ export class Client {
     const authorValue = author ? `${author.name}<${author.email}>` : 'unknown';
     const message = await this.message(commit.data.commit.message);
 
-    return [
+    const fields: Field[] = [
       {
         title: 'repo',
         value: this.repositoryLink,
         short: false,
       },
-      this.refField,
-      {
+    ];
+
+    const prField = this.pullRequestField;
+    if (prField) {
+      fields.push(prField);
+    } else {
+      fields.push(this.refField);
+      fields.push({
         title: 'commit',
         value: this.commitLink,
         short: false,
-      },
+      });
+    }
+
+    fields.push(
       {
         title: 'author',
         value: authorValue,
@@ -133,7 +142,22 @@ export class Client {
         value: this.workflowLink,
         short: false,
       },
-    ];
+    );
+
+    return fields;
+  }
+
+  private get pullRequestField(): Field | null {
+    const pr = github.context.payload.pull_request;
+    if (!pr) return null;
+    const url = (pr as { html_url?: string }).html_url;
+    const title = (pr as { title?: string }).title;
+    if (!url || !title) return null;
+    return {
+      title: 'pull request',
+      value: `<${url}|${title}>`,
+      short: false,
+    };
   }
 
   private get textSuccess() {

--- a/src/client.ts
+++ b/src/client.ts
@@ -92,6 +92,71 @@ export class Client {
   }
 
   private async fields(): Promise<Field[]> {
+    const fields: Field[] = [
+      {
+        title: 'repo',
+        value: this.repositoryLink,
+        short: false,
+      },
+    ];
+
+    const prFields = this.pullRequestFields;
+    if (prFields) {
+      fields.push(...prFields);
+    } else {
+      fields.push(...(await this.commitFields()));
+    }
+
+    fields.push({
+      title: 'workflow',
+      value: this.workflowLink,
+      short: false,
+    });
+
+    return fields;
+  }
+
+  private get pullRequestFields(): Field[] | null {
+    const pr = github.context.payload.pull_request as
+      | {
+          html_url?: string;
+          title?: string;
+          body?: string | null;
+          user?: { login?: string; html_url?: string };
+        }
+      | undefined;
+    if (!pr) return null;
+    const url = pr.html_url;
+    const title = pr.title;
+    if (!url || !title) return null;
+
+    const login = pr.user?.login;
+    const userUrl = pr.user?.html_url;
+    let authorValue = 'unknown';
+    if (login) {
+      authorValue = userUrl ? `<${userUrl}|${login}>` : login;
+    }
+
+    return [
+      {
+        title: 'pull_request',
+        value: `<${url}|${title}>`,
+        short: false,
+      },
+      {
+        title: 'author',
+        value: authorValue,
+        short: false,
+      },
+      {
+        title: 'message',
+        value: pr.body ?? '',
+        short: false,
+      },
+    ];
+  }
+
+  private async commitFields(): Promise<Field[]> {
     if (this.octokit === undefined) {
       throw Error('Specify secrets.GITHUB_TOKEN');
     }
@@ -106,27 +171,13 @@ export class Client {
     const authorValue = author ? `${author.name}<${author.email}>` : 'unknown';
     const message = await this.message(commit.data.commit.message);
 
-    const fields: Field[] = [
+    return [
+      this.refField,
       {
-        title: 'repo',
-        value: this.repositoryLink,
-        short: false,
-      },
-    ];
-
-    const prField = this.pullRequestField;
-    if (prField) {
-      fields.push(prField);
-    } else {
-      fields.push(this.refField);
-      fields.push({
         title: 'commit',
         value: this.commitLink,
         short: false,
-      });
-    }
-
-    fields.push(
+      },
       {
         title: 'author',
         value: authorValue,
@@ -137,27 +188,7 @@ export class Client {
         value: message,
         short: false,
       },
-      {
-        title: 'workflow',
-        value: this.workflowLink,
-        short: false,
-      },
-    );
-
-    return fields;
-  }
-
-  private get pullRequestField(): Field | null {
-    const pr = github.context.payload.pull_request;
-    if (!pr) return null;
-    const url = (pr as { html_url?: string }).html_url;
-    const title = (pr as { title?: string }).title;
-    if (!url || !title) return null;
-    return {
-      title: 'pull request',
-      value: `<${url}|${title}>`,
-      short: false,
-    };
+    ];
   }
 
   private get textSuccess() {

--- a/src/client.ts
+++ b/src/client.ts
@@ -12,6 +12,13 @@ export interface With {
   text_on_cancel: string;
   title: string;
   only_mention_fail: string;
+  notice_on: string;
+}
+
+interface Field {
+  title: string;
+  value: string;
+  short: boolean;
 }
 
 const groupMention = ['here', 'channel'];
@@ -37,6 +44,17 @@ export class Client {
       throw new Error('Specify secrets.SLACK_WEBHOOK_URL');
     }
     this.webhook = new IncomingWebhook(webhookUrl);
+  }
+
+  shouldNotice(status: string): boolean {
+    const raw = this.with.notice_on;
+    if (raw === '') return true;
+    const allowed = raw
+      .split(',')
+      .map(s => s.trim().toLowerCase())
+      .filter(s => s !== '');
+    if (allowed.length === 0) return true;
+    return allowed.includes(status.toLowerCase());
   }
 
   async success() {
@@ -85,7 +103,7 @@ export class Client {
     };
   }
 
-  private async fields() {
+  private async fields(): Promise<Field[]> {
     if (this.octokit === undefined) {
       throw Error('Specify secrets.GITHUB_TOKEN');
     }
@@ -100,22 +118,19 @@ export class Client {
     const authorValue = author ? `${author.name}<${author.email}>` : 'unknown';
     const message = await this.message(commit.data.commit.message);
 
-    return [
+    const fields: Array<Field | null> = [
       {
         title: 'repo',
         value: this.repositoryLink,
         short: false,
       },
-      {
-        title: 'ref',
-        value: github.context.ref,
-        short: false,
-      },
+      this.refField,
       {
         title: 'commit',
         value: this.commitLink,
         short: false,
       },
+      this.compareField,
       {
         title: 'author',
         value: authorValue,
@@ -126,12 +141,16 @@ export class Client {
         value: message,
         short: false,
       },
+      this.pullRequestField,
       {
         title: 'workflow',
         value: this.workflowLink,
         short: false,
       },
+      await this.failedStepsField(),
     ];
+
+    return fields.filter((f): f is Field => f !== null);
   }
 
   private get textSuccess() {
@@ -182,6 +201,73 @@ export class Client {
     const { owner, repo } = github.context.repo;
 
     return `<https://github.com/${owner}/${repo}|${owner}/${repo}>`;
+  }
+
+  private get refField(): Field {
+    const ref = github.context.ref;
+    const branchMatch = ref.match(/^refs\/heads\/(.+)$/);
+    if (branchMatch) {
+      return { title: 'branch', value: branchMatch[1], short: false };
+    }
+    const tagMatch = ref.match(/^refs\/tags\/(.+)$/);
+    if (tagMatch) {
+      return { title: 'tag', value: tagMatch[1], short: false };
+    }
+    return { title: 'ref', value: ref, short: false };
+  }
+
+  private get compareField(): Field | null {
+    const compare = (github.context.payload as { compare?: unknown }).compare;
+    if (typeof compare !== 'string' || compare === '') return null;
+    return { title: 'diff', value: `<${compare}|compare>`, short: false };
+  }
+
+  private get pullRequestField(): Field | null {
+    const pr = github.context.payload.pull_request;
+    if (!pr) return null;
+    const number = pr.number;
+    const title = (pr as { title?: string }).title ?? '';
+    const url = (pr as { html_url?: string }).html_url ?? '';
+    if (!url) return null;
+    return {
+      title: 'pull_request',
+      value: `<${url}|#${number}> ${title}`,
+      short: false,
+    };
+  }
+
+  private async failedStepsField(): Promise<Field | null> {
+    if (this.with.status.toLowerCase() !== 'failure') return null;
+    if (this.octokit === undefined) return null;
+    const { owner, repo } = github.context.repo;
+    try {
+      const { data } = await this.octokit.rest.actions.listJobsForWorkflowRun({
+        owner,
+        repo,
+        run_id: parseInt(this.runId, 10),
+      });
+      const failed: string[] = [];
+      for (const job of data.jobs) {
+        if (job.conclusion !== 'failure') continue;
+        const steps = job.steps ?? [];
+        for (const step of steps) {
+          if (step.conclusion === 'failure') {
+            failed.push(`${job.name} > ${step.name}`);
+          }
+        }
+      }
+      if (failed.length === 0) return null;
+      return {
+        title: 'failed_steps',
+        value: failed.map(s => `• ${s}`).join('\n'),
+        short: false,
+      };
+    } catch (e) {
+      core.debug(
+        `failedStepsField error: ${e instanceof Error ? e.message : String(e)}`,
+      );
+      return null;
+    }
   }
 
   private async message(message: string) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -205,14 +205,17 @@ export class Client {
   private get refField(): Field {
     const ref = github.context.ref;
     const { owner, repo } = github.context.repo;
-    const m = ref.match(/^refs\/(?:heads|tags)\/(.+)$/);
-    if (m) {
-      const name = m[1];
-      return {
-        title: 'ref',
-        value: `<https://github.com/${owner}/${repo}/tree/${name}|${name}>`,
-        short: false,
-      };
+    const branchMatch = ref.match(/^refs\/heads\/(.+)$/);
+    if (branchMatch) {
+      const name = branchMatch[1];
+      const link = `<https://github.com/${owner}/${repo}/tree/${name}|branch>`;
+      return { title: 'ref', value: `${ref} ${link}`, short: false };
+    }
+    const tagMatch = ref.match(/^refs\/tags\/(.+)$/);
+    if (tagMatch) {
+      const name = tagMatch[1];
+      const link = `<https://github.com/${owner}/${repo}/tree/${name}|tag>`;
+      return { title: 'ref', value: `${ref} ${link}`, short: false };
     }
     return { title: 'ref', value: ref, short: false };
   }
@@ -255,7 +258,7 @@ export class Client {
       }
       if (failed.length === 0) return null;
       return {
-        title: 'failed_steps',
+        title: 'workflow failed steps',
         value: failed.map(s => `• ${s}`).join('\n'),
         short: false,
       };

--- a/src/client.ts
+++ b/src/client.ts
@@ -130,7 +130,6 @@ export class Client {
         value: this.commitLink,
         short: false,
       },
-      this.compareField,
       {
         title: 'author',
         value: authorValue,
@@ -205,21 +204,17 @@ export class Client {
 
   private get refField(): Field {
     const ref = github.context.ref;
-    const branchMatch = ref.match(/^refs\/heads\/(.+)$/);
-    if (branchMatch) {
-      return { title: 'branch', value: branchMatch[1], short: false };
-    }
-    const tagMatch = ref.match(/^refs\/tags\/(.+)$/);
-    if (tagMatch) {
-      return { title: 'tag', value: tagMatch[1], short: false };
+    const { owner, repo } = github.context.repo;
+    const m = ref.match(/^refs\/(?:heads|tags)\/(.+)$/);
+    if (m) {
+      const name = m[1];
+      return {
+        title: 'ref',
+        value: `<https://github.com/${owner}/${repo}/tree/${name}|${name}>`,
+        short: false,
+      };
     }
     return { title: 'ref', value: ref, short: false };
-  }
-
-  private get compareField(): Field | null {
-    const compare = (github.context.payload as { compare?: unknown }).compare;
-    if (typeof compare !== 'string' || compare === '') return null;
-    return { title: 'diff', value: `<${compare}|compare>`, short: false };
   }
 
   private get pullRequestField(): Field | null {
@@ -246,9 +241,11 @@ export class Client {
         repo,
         run_id: parseInt(this.runId, 10),
       });
+      // Don't filter by job.conclusion: when this action runs, the
+      // current job's conclusion is still null. Scan all steps and
+      // pick whichever ones report conclusion === 'failure'.
       const failed: string[] = [];
       for (const job of data.jobs) {
-        if (job.conclusion !== 'failure') continue;
         const steps = job.steps ?? [];
         for (const step of steps) {
           if (step.conclusion === 'failure') {

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,7 +13,6 @@ async function run(): Promise<void> {
     const text_on_success = core.getInput('text_on_success');
     const text_on_fail = core.getInput('text_on_fail');
     const text_on_cancel = core.getInput('text_on_cancel');
-    const notice_on = core.getInput('notice_on');
     const rawPayload = core.getInput('payload');
 
     core.debug(`status: ${status}`);
@@ -24,7 +23,6 @@ async function run(): Promise<void> {
     core.debug(`text_on_success: ${text_on_success}`);
     core.debug(`text_on_fail: ${text_on_fail}`);
     core.debug(`text_on_cancel: ${text_on_cancel}`);
-    core.debug(`notice_on: ${notice_on}`);
     core.debug(`rawPayload: ${rawPayload}`);
 
     const client = new Client(
@@ -37,16 +35,10 @@ async function run(): Promise<void> {
         text_on_cancel,
         title,
         only_mention_fail,
-        notice_on,
       },
       process.env.GITHUB_TOKEN,
       process.env.SLACK_WEBHOOK_URL,
     );
-
-    if (status !== 'custom' && !client.shouldNotice(status)) {
-      core.info(`Skipped: status "${status}" not in notice_on "${notice_on}"`);
-      return;
-    }
 
     switch (status) {
       case 'success':

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,7 @@ async function run(): Promise<void> {
     const text_on_success = core.getInput('text_on_success');
     const text_on_fail = core.getInput('text_on_fail');
     const text_on_cancel = core.getInput('text_on_cancel');
+    const notice_on = core.getInput('notice_on');
     const rawPayload = core.getInput('payload');
 
     core.debug(`status: ${status}`);
@@ -23,6 +24,7 @@ async function run(): Promise<void> {
     core.debug(`text_on_success: ${text_on_success}`);
     core.debug(`text_on_fail: ${text_on_fail}`);
     core.debug(`text_on_cancel: ${text_on_cancel}`);
+    core.debug(`notice_on: ${notice_on}`);
     core.debug(`rawPayload: ${rawPayload}`);
 
     const client = new Client(
@@ -35,10 +37,16 @@ async function run(): Promise<void> {
         text_on_cancel,
         title,
         only_mention_fail,
+        notice_on,
       },
       process.env.GITHUB_TOKEN,
       process.env.SLACK_WEBHOOK_URL,
     );
+
+    if (status !== 'custom' && !client.shouldNotice(status)) {
+      core.info(`Skipped: status "${status}" not in notice_on "${notice_on}"`);
+      return;
+    }
 
     switch (status) {
       case 'success':

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,7 @@ async function run(): Promise<void> {
     const text_on_success = core.getInput('text_on_success');
     const text_on_fail = core.getInput('text_on_fail');
     const text_on_cancel = core.getInput('text_on_cancel');
+    const show_message = core.getInput('show_message');
     const rawPayload = core.getInput('payload');
 
     core.debug(`status: ${status}`);
@@ -23,6 +24,7 @@ async function run(): Promise<void> {
     core.debug(`text_on_success: ${text_on_success}`);
     core.debug(`text_on_fail: ${text_on_fail}`);
     core.debug(`text_on_cancel: ${text_on_cancel}`);
+    core.debug(`show_message: ${show_message}`);
     core.debug(`rawPayload: ${rawPayload}`);
 
     const client = new Client(
@@ -35,6 +37,7 @@ async function run(): Promise<void> {
         text_on_cancel,
         title,
         only_mention_fail,
+        show_message,
       },
       process.env.GITHUB_TOKEN,
       process.env.SLACK_WEBHOOK_URL,


### PR DESCRIPTION
## Summary

Two changes to the default message, plus one long-standing fix:

1. **`ref` field gains a `branch` / `tag` link** suffix on top of
   the raw ref string (push / tag events).
2. **On `pull_request` / `pull_request_target` events, the four
   commit-derived fields (`ref`, `commit`, commit-author, commit-
   message) are replaced with their PR equivalents**: `pull_request`
   (PR title linked to its URL), `author` (PR creator's GitHub login
   linked to their profile), `message` (PR description body).
3. **`action.yml` finally declares `text_on_success` / `text_on_fail`
   / `text_on_cancel`.** These have been read in `main.ts` since
   2021 but were absent from the input schema, so every use produced
   an "Unexpected input(s)" warning. Now warning-free.

That is the entire scope. Earlier revisions of this PR also added a
separate `pull_request` field alongside the commit ones, a
`workflow failed steps` field, a `notice_on` input, and a
`compare`/`diff` link; **all of those were dropped on review** since
they either duplicated existing capability or were already covered
by GitHub Actions built-ins (`if: failure()`, the workflow link,
etc.).

## Field layout

**Push / tag / other non-PR events**

| Field      | Notes |
| ---------- | --- |
| `repo`     | Repository link. |
| `ref`      | Raw ref + `branch` / `tag` link to `tree/<name>`. |
| `commit`   | Commit SHA linked to GitHub. |
| `author`   | Commit author `name<email>`. |
| `message`  | Commit message (merge-commit PR bodies appended). |
| `workflow` | Workflow name linked to the run. |

**PR events**

| Field          | Notes |
| -------------- | --- |
| `repo`         | Repository link. |
| `pull_request` | PR title linked to the PR. |
| `author`       | PR creator's GitHub login linked to their profile. |
| `message`      | PR description body. |
| `workflow`     | Workflow name linked to the run. |

## Files

- `action.yml` — declares `text_on_success` / `text_on_fail` /
  `text_on_cancel`.
- `src/client.ts` — `fields()` splits into `commitFields()` and
  `pullRequestFields` based on event; `refField` builds
  `<raw>  <link|branch>` (or `<link|tag>`); `getCommit` is skipped
  on PR events.
- `.github/workflows/slack-pre.yml` — covers `text_on_*` on the
  existing Succeeded / Failed / Canceled checks so the action.yml
  declaration is exercised.
- `README.md` — splits the Message Fields table into push and PR
  layouts.
- `dist/index.js` — re-packed.

## Test plan

Integration on `pre` (most recent run: `ead3dab`):

- [x] No more `Unexpected input(s) 'text_on_*'` warnings.
- [ ] Push event — `ref` field renders as `refs/heads/pre  branch`
      with "branch" as a clickable link.
- [ ] Push a tag — `ref` renders as `refs/tags/<name>  tag` with
      "tag" as a clickable link. (Not exercised by `push: pre`;
      manual.)
- [ ] PR event — `ref` / `commit` are absent; `pull_request` field
      shows PR title, `author` shows PR creator login (linked),
      `message` shows PR body. (Not exercised by `push: pre`;
      verify on any PR that uses `@pre`.)
- [ ] Succeeded / Failed / Canceled Check messages show the
      `text_on_*` overrides instead of the default text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)