### PR TITLE
chore: release v4.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "slack-notice-action",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "slack-notice-action",
-      "version": "4.0.0",
+      "version": "4.1.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slack-notice-action",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "private": true,
   "description": "A Github Action to notify slack.",
   "type": "module",


### PR DESCRIPTION
## Summary

Bump `package.json` / `package-lock.json` to **4.1.0**.

Since v4.0.0, the following landed on `main`:
- **feat: Bot Token transport mode** — `SLACK_BOT_TOKEN` selects the Bot Token transport, with `channel` / `username` / `icon_emoji` / `icon_url` overrides
- **ci: workflow_dispatch E2E** — `.github/workflows/e2e.yml` exercises both Webhook and Bot Token transports end-to-end
- **docs: e2e runbook + DEVELOPMENT.md rewrite**
- **chore: webhook secret consolidation** — `SLACK_WEBHOOK_URL_FOR_INTEGRATION_TEST` removed

Bot Token mode is additive and Webhook mode is unchanged, so this is a minor bump.

## Test plan

- [x] E2E (`mode=both`) PASS on `main` after the recent `icon_url` fix
- [ ] Merge → fast-forward `v4` → tag `v4.1.0`