### PR TITLE
chore: release v4.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "slack-notice-action",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "slack-notice-action",
-      "version": "4.1.0",
+      "version": "4.1.1",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slack-notice-action",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "private": true,
   "description": "A Github Action to notify slack.",
   "type": "module",


### PR DESCRIPTION
## Summary

Patch release. Bumps `package.json` / `package-lock.json` to **4.1.1**.

Picks up the security fix from PR #63 (`@actions/core` v1 → v3) which dropped the transitive vulnerable `undici@5.29.0`. Closes the 5 dependabot alerts.

## Test plan

- [x] E2E (`mode=both`) on `chore/bump-actions-core` PASS prior to merging #63
- [ ] Merge → fast-forward `v4` → tag `v4.1.1`