### PR TITLE
chore: release v4.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## v4.1.2
+
+### Bug Fixes
+
+- **Declare `text_on_success` / `text_on_fail` / `text_on_cancel` in `action.yml`.**
+  These inputs were already implemented and documented, but were missing from
+  the `action.yml` `inputs:` declaration, so passing them produced an
+  `Unexpected input(s)` warning on every run. The inputs are now declared and
+  the warning is gone.
+
+## v4.1.1
+
+### Security
+
+- **Bump `@actions/core` v1 → v3** to drop the transitive vulnerable
+  `undici` 5.29.0. Clears five Dependabot alerts. No API changes.
+
+## v4.1.0
+
+### Added
+
+- **Bot Token transport mode.** Set the `SLACK_BOT_TOKEN` (`xoxb-…`)
+  environment variable to post via the Slack Web API (`chat.postMessage`)
+  instead of an Incoming Webhook. In this mode the `channel`, `username`,
+  `icon_emoji`, and `icon_url` inputs are honored again (Slack App
+  webhooks ignore those per-message overrides). `channel` is **required**
+  when using `SLACK_BOT_TOKEN`. Webhook mode via `SLACK_WEBHOOK_URL`
+  continues to work unchanged.
+
 ## v4.0.0
 
 ### Breaking Changes

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,15 @@ inputs:
   text:
     description: You can overwrite text.
     default: ''
+  text_on_success:
+    description: Override text on success only. Wins over `text`.
+    default: ''
+  text_on_fail:
+    description: Override text on failure only. Wins over `text`.
+    default: ''
+  text_on_cancel:
+    description: Override text on cancellation only. Wins over `text`.
+    default: ''
   channel:
     description: |
       Slack channel ID or name (e.g. `C0123456789` or `#alerts`).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "slack-notice-action",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "slack-notice-action",
-      "version": "4.1.1",
+      "version": "4.1.2",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slack-notice-action",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "private": true,
   "description": "A Github Action to notify slack.",
   "type": "module",


### PR DESCRIPTION
## Summary

- **fix:** declare `text_on_success` / `text_on_fail` / `text_on_cancel` in `action.yml`. These inputs were already implemented in `src` and documented in the README, but were missing from `action.yml`'s `inputs:` declaration, so passing any of them emitted an `Unexpected input(s)` warning on every run. Declaring them silences the warning.
- **chore:** bump version to 4.1.2.
- **docs:** backfill CHANGELOG entries for v4.1.0 (Bot Token transport mode) and v4.1.1 (security: drop vulnerable undici via `@actions/core` v3), which were never recorded, plus the new v4.1.2 entry.

## Verification

- `npm run release` (build + pack) produces no `dist/` diff — `uncommitted.yml` will pass.
- `npm test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)