### PR TITLE
chore: release v4.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v4.1.3
+
+### Security
+
+- **Bump bundled vulnerable transitive dependencies.** Updated `undici`
+  6.25.0 → 6.27.0 and `form-data` 4.0.5 → 4.0.6 (both bundled into
+  `dist/index.js` and shipped to consumers), plus the dev-only
+  `@babel/core` 7.29.0 → 7.29.7. Clears six Dependabot alerts. No API
+  changes.
+
 ## v4.1.2
 
 ### Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "slack-notice-action",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "slack-notice-action",
-      "version": "4.1.2",
+      "version": "4.1.3",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slack-notice-action",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "private": true,
   "description": "A Github Action to notify slack.",
   "type": "module",


### PR DESCRIPTION
## Summary

Release v4.1.3 — ships the bundled security bumps from #70 to consumers.

- `undici` 6.25.0 → 6.27.0 and `form-data` 4.0.5 → 4.0.6 (bundled into `dist`, shipped to consumers)
- `@babel/core` 7.29.0 → 7.29.7 (dev only)
- Clears six Dependabot alerts. No API changes.

Version bumped to 4.1.3 + CHANGELOG entry. `dist` is unchanged from main (the dependency bumps already landed in #70).

🤖 Generated with [Claude Code](https://claude.com/claude-code)